### PR TITLE
Update conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ The code has been tested with PyTorch 1.6 and Cuda 10.1.
 ```Shell
 conda create --name raft
 conda activate raft
-conda install pytorch=1.6.0 torchvision=0.7.0 cudatoolkit=10.1 -c pytorch
-conda install matplotlib
-conda install tensorboard
-conda install scipy
-conda install opencv
+conda install pytorch=1.6.0 torchvision=0.7.0 cudatoolkit=10.1 matplotlib tensorboard scipy opencv -c pytorch
 ```
 
 ## Demos


### PR DESCRIPTION
Changes the conda install instructions to a one-liner instead of multiple command lines.
This is an important change, because with the current version of conda, using the multiline version results the environment not being able to be solved in the later added packages due to clashes with the former, and thus not being able to correctly install all of the requirements.
However, the one line version solves this and allows the install to proceed much more easily and quickly.