### PR TITLE
fix runtime error for PyTorch<1.6

### DIFF
--- a/train.py
+++ b/train.py
@@ -26,7 +26,7 @@ try:
 except:
     # dummy GradScaler for PyTorch < 1.6
     class GradScaler:
-        def __init__(self):
+        def __init__(self, enabled=None):
             pass
         def scale(self, loss):
             return loss


### PR DESCRIPTION
Python will complain of the missing of the default parameter "enabled" for PyTorch<1.6. Fix it.